### PR TITLE
[FE] Discover Page 유저 추천 리스트 에러 해결

### DIFF
--- a/client/src/components/discover/LikeDisLikeBox.tsx
+++ b/client/src/components/discover/LikeDisLikeBox.tsx
@@ -8,31 +8,22 @@ type Props = {
   userId: number;
   currentUserIndex: number;
   setCurrentUserIndex: React.Dispatch<React.SetStateAction<number>>;
-  hasNextPage: boolean | undefined;
   refetch: () => void;
+  dataLength: number;
 };
 
-export const LikeDisLikeBox = ({
-  userId,
-  setCurrentUserIndex,
-  currentUserIndex,
-  hasNextPage,
-  refetch,
-}: Props) => {
+export const LikeDisLikeBox = (props: Props) => {
+  const { userId, setCurrentUserIndex, currentUserIndex, refetch, dataLength } = props;
   const { postLikeFn } = usePostLike();
   const { postDisLikeFn } = usePostDisLike();
 
   const handleLike = () => {
-    if (currentUserIndex === 9) {
-      if (hasNextPage) {
-        postLikeFn(userId, {
-          onSuccess: () => {
-            refetch();
-          },
-        });
-      } else {
-        postLikeFn(userId);
-      }
+    if (currentUserIndex === dataLength - 1) {
+      postLikeFn(userId, {
+        onSuccess: () => {
+          refetch();
+        },
+      });
     } else {
       postLikeFn(userId);
       setCurrentUserIndex(currentUserIndex + 1);
@@ -40,29 +31,25 @@ export const LikeDisLikeBox = ({
   };
 
   const handleDisLike = () => {
-    if (currentUserIndex === 9) {
-      if (hasNextPage) {
-        postDisLikeFn(userId, {
-          onSuccess: () => {
-            refetch();
-          },
-        });
-      } else {
-        postDisLikeFn(userId);
-      }
+    if (currentUserIndex === dataLength - 1) {
+      postDisLikeFn(userId, {
+        onSuccess: () => {
+          refetch();
+        },
+      });
     } else {
       postDisLikeFn(userId);
       setCurrentUserIndex(currentUserIndex + 1);
     }
   };
   return (
-    <div className="flex justify-center gap-8 mt-8">
+    <section className="flex justify-center gap-8 mt-8">
       <button className="flex items-center justify-center bg-white rounded-full shadow-3xl w-14 h-14">
         <ThumbDown onClick={handleDisLike} />
       </button>
       <button className="flex items-center justify-center bg-white rounded-full shadow-3xl w-14 h-14 ">
         <ThumbUp onClick={handleLike} />
       </button>
-    </div>
+    </section>
   );
 };

--- a/client/src/pages/DiscoverPage.tsx
+++ b/client/src/pages/DiscoverPage.tsx
@@ -25,7 +25,7 @@ export type UserList = {
 
 function DiscoverPage() {
   const [currentUserIndex, setCurrentUserIndex] = useState<number>(0);
-  const { data, isLoading, isSuccess, hasNextPage, refetch } = useGetRecommendedUserList();
+  const { data, isLoading, isSuccess, refetch } = useGetRecommendedUserList();
 
   useEffect(() => {
     if (data) {
@@ -59,8 +59,8 @@ function DiscoverPage() {
               userId={dataPath.content[currentUserIndex].id}
               currentUserIndex={currentUserIndex}
               setCurrentUserIndex={setCurrentUserIndex}
-              hasNextPage={hasNextPage}
               refetch={refetch}
+              dataLength={dataPath.content.length}
             />
           </>
         )}


### PR DESCRIPTION
## 제목

- [FE] Discover Page 유저 추천 리스트 에러 해결

## 작업 내용
 
1.  유저 추천 리스트 없을 시, 다른 탭 갔다 오면 이전 데이터 보이는 에러 해결

close #130 
