### PR TITLE
[FE] Discover Page 유저 추천 카드 기능 수정

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blind</title>
   </head>
-  <body>
+  <body class="touch-none">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/client/src/components/discover/DetailField.tsx
+++ b/client/src/components/discover/DetailField.tsx
@@ -1,5 +1,4 @@
 import { QUESTIONS } from 'assets/config';
-import React from 'react';
 type Question = {
   id: number;
   status: boolean;
@@ -12,7 +11,7 @@ export const DetailField = ({ answer }: Props) => {
   const answerSort = answer.sort((cur, next) => cur.id - next.id);
 
   return (
-    <section className="overflow-auto">
+    <section>
       {QUESTIONS.map((question, index) => {
         return (
           <div className="mb-6" key={index}>

--- a/client/src/components/discover/RecommendedUserCard.tsx
+++ b/client/src/components/discover/RecommendedUserCard.tsx
@@ -2,6 +2,7 @@ import { useModal } from 'hooks/useModal';
 import { DetailField } from './DetailField';
 import { Interests, Question } from 'recoil/user/atoms';
 import { ReactComponent as ArrowRight } from 'assets/icons/Arrow_Right.svg';
+import { useEffect } from 'react';
 
 type Props = {
   id: number;
@@ -16,9 +17,15 @@ type Props = {
 };
 
 export const RecommendedUserCard = (userInfo: Props) => {
-  const { nickname, region, mbti, interests, questions, selfIntroduction } = userInfo;
+  const { id, nickname, region, mbti, interests, questions, selfIntroduction } = userInfo;
   const { isModalOpen, handleToggleBtn } = useModal();
   const interestsSort = interests.sort((cur, next) => cur.id - next.id);
+
+  useEffect(() => {
+    if (isModalOpen) {
+      handleToggleBtn();
+    }
+  }, [id]);
 
   return (
     <>
@@ -31,7 +38,7 @@ export const RecommendedUserCard = (userInfo: Props) => {
             </button>
           </section>
 
-          <section className="px-5 overflow-auto h-5/6">
+          <section className="px-5 overflow-auto scrollbar h-5/6">
             <DetailField answer={questions} />
           </section>
         </main>


### PR DESCRIPTION
## 제목

- [FE] Discover Page 유저 추천 카드 기능 수정

## 작업 내용

1. 추천 유저 카드의 more 정보를 보는 상태가 됐을 때, 유저 좋아요 누를 시 카드 UI 앞면으로 변경 기능 추가

2. 모바일에서 touch 중에 새로운 이벤트 일어나지 않게 기능 추가

3. 불필요한 css 제거

close #144
